### PR TITLE
Update to Tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/neonphog/tokio_safe_block_on"
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "0.2", features = ["time", "blocking", "rt-core", "rt-util", "rt-threaded"] }
+tokio = { version = "0.3", features = ["time", "rt", "io-util", "rt-multi-thread"] }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.3", features = ["macros"] }
 assert_matches = "1"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ without blocking a tokio core thread or busy looping the cpu.
 ## Example
 
 ```rust
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     // we need to ensure we are in the context of a tokio task
     tokio::task::spawn(async move {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ async fn main() {
                 // async code to poll synchronously
                 async move {
                     // simulate some async work
-                    tokio::time::delay_for(
+                    tokio::time::sleep(
                         std::time::Duration::from_millis(2)
                     ).await;
 


### PR DESCRIPTION
encapsulates https://github.com/neonphog/tokio_safe_block_on/pull/6 but runs readme rebuild